### PR TITLE
Sad testing

### DIFF
--- a/app.js
+++ b/app.js
@@ -38,7 +38,7 @@ app.post('/api/v1/projects', (request, response) => {
     if (!project[requiredParameter]) {
       return response
         .status(422)
-        .send({ error: `Expected format: { projectId: <Integer>, name: <String> }. You're missing a "${requiredParameter}" property.` });
+        .send({ error: `Expected format: { projectId: <Integer>, name: <String> }. You're missing a property.` });
     }
   }
 
@@ -106,7 +106,7 @@ app.post('/api/v1/palettes', (request, response) => {
     if (!palette[requiredParameter]) {
       return response
         .status(422)
-        .send({ error: `Expected format: { projectId: <Integer>, name: <String>, colors: <Strings> }. You're missing a "${requiredParameter}" property.` });
+        .send({ error: `Expected format: { projectId: <Integer>, name: <String>, colors: <Strings> }. You're missing a property.` });
     }
   }
 

--- a/app.test.js
+++ b/app.test.js
@@ -61,6 +61,15 @@ describe('Server', () => {
 	 		expect(response.status).toBe(201);
 	 		expect(project.name).toEqual(newProject.name);
 		});
+
+		it('should return a 422 and the message containing data types for required parameters', async () => {
+	 		const invalidName = 2;
+
+	 		const response = await request(app).post('/api/v1/projects');
+
+	 		expect(response.status).toBe(422);
+	 		expect(response.body.error).toEqual('Expected format: { projectId: <Integer>, name: <String> }. You\'re missing a property.');
+	 	});
 	});
 
 	describe('DELETE /api/v1/projects/:projectId', () => {
@@ -129,7 +138,7 @@ describe('Server', () => {
 	 		expect(palette.name).toEqual(newPalette.name);
 		});
 
-			it('should return a 422 and the message containing data types for required parameters', async () => {
+		it('should return a 422 and the message containing data types for required parameters', async () => {
 	 		const invalidName = 2;
 
 	 		const response = await request(app).post('/api/v1/palettes');

--- a/app.test.js
+++ b/app.test.js
@@ -128,6 +128,15 @@ describe('Server', () => {
 	 		expect(response.status).toBe(201);
 	 		expect(palette.name).toEqual(newPalette.name);
 		});
+
+			it('should return a 422 and the message containing data types for required parameters', async () => {
+	 		const invalidName = 2;
+
+	 		const response = await request(app).post('/api/v1/palettes');
+
+	 		expect(response.status).toBe(422);
+	 		expect(response.body.error).toEqual('Expected format: { projectId: <Integer>, name: <String>, colors: <Strings> }. You\'re missing a property.');
+	 	});
 	});
 
 	describe('DELETE /api/v1/palettes/:id', () => {


### PR DESCRIPTION
#### What's this PR do?
Add testing for sad path when posting new palette
Add testing for sad path when posting new project
#### Where should the reviewer start?
In app.test.js, on the project posting test, the sad path
#### How should this be manually tested?
Run ```npm test``` in the terminal
#### What are the relevant tickets?
Issue #13 
